### PR TITLE
Ref #2: Updated wichitalks capitalisation

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var orgs = map[string]bool{
 	"MakeICT":        true,
 	"openwichita":    true,
 	"startupwichita": true,
-	"wichitalks":     true,
+	"Wichitalks":     true,
 	"Ennovar":        true,
 }
 


### PR DESCRIPTION
Wichitalks wasn't showing up as valid for #Hacktoberfest pull requests because wichitalks needed to be capitalised.