### PR TITLE
Adding issues endpoint

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+	
+	"github.com/pkg/errors"
+)
+
+type Issue struct {
+	Title string
+	Date  time.Time
+	URL   string
+	Repo  Repo
+}
+
+func issues(w http.ResponseWriter, r *http.Request) {
+	u, _, ok := findUser(r)
+	if !ok {
+		http.Error(w, "you are not logged in", http.StatusUnauthorized)
+		return
+	}
+
+	issues, err := fetchIssues(u.AccessToken)
+	if err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(issues); err != nil {
+		log.Println(err)
+	}
+	
+	log.Println(issues)
+}
+
+func fetchIssues(token string) ([]Issue, error) {
+	req, err := http.NewRequest("GET", "https://api.github.com/search/issues", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not build request")
+	}
+	
+	q := "is:open is:issue label:hacktoberfest"
+	
+	// add specific organizations to the search
+	for k, v := range orgs {
+		if v == true {
+			q += fmt.Sprintf(" org:%s", k)
+		}
+	}
+	
+	// add specific projects to the search
+	for k, v := range projects {
+		if v == true {
+			q += fmt.Sprintf(" repo:%s", k)
+		}
+	}
+
+	vals := req.URL.Query()
+	vals.Add("q", q)
+	req.URL.RawQuery = vals.Encode()
+
+	// Use their access token so it counts against their rate limit
+	if token != "" {
+		req.Header.Add("Authorization", "token "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not execute request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, errors.Wrapf(err, "status was %d, not 200", resp.StatusCode)
+	}
+
+	var data struct {
+		Items []struct {
+			Title     string    `json:"title"`
+			CreatedAt time.Time `json:"created_at"`
+			URL       string    `json:"url"`
+			RepoURL   string    `json:"repository_url"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, errors.Wrap(err, "could not decode json")
+	}
+
+	issues := []Issue{}
+	for _, item := range data.Items {
+		issue := Issue{
+			Title: item.Title,
+			Date:  item.CreatedAt,
+			URL:   item.URL,
+		}
+
+		issue.Repo, err = repoFromURL(item.RepoURL)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not identify repo from %s", item.RepoURL)
+		}
+
+		issues = append(issues, issue)
+	}
+
+	return issues, nil
+}

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func main() {
 	r.Get("/auth/{provider}/callback", authCallback)
 	r.Get("/auth/{provider}", gothic.BeginAuthHandler)
 
+	r.Get("/api/issues", issues)
 	r.Get("/api/prs", prs)
 	r.Get("/api/share", getShare)
 	r.Put("/api/share", updateShare)

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -1,6 +1,7 @@
 // On document load we wire up all of the events
 $(function() {
   $('#check').click(checkPRs);
+  checkIssues();
   $('#share_info').change(saveShareInfo);
 
   if ($('#sponsorShareModal').length) {
@@ -11,6 +12,32 @@ $(function() {
     getShareInfo();
   }
 });
+
+function checkIssues() {
+  var results = $('#issues_results');
+
+  $.ajax({type: 'GET', url: '/api/issues'})
+    .then(function(data) {
+        if (data != null && data.length >= 0) {  
+          var rows = '';
+          data.forEach(function(issue, j) {
+            var row = `<tr>
+                        <td>` + issue["Title"] + `</td>
+                        <td>` +  issue["Repo"]["Owner"] + "/" + issue["Repo"]["Name"] + `</td>
+                        <td> <a class="btn btn-large btn-success" href="https://github.com/` + issue["URL"].split("repos")[1] + `" target="_blank">Open Issue URL</a></td>
+                      </tr>`
+            rows += row;
+          })
+          $("#issues").append(rows);
+      }
+      $(document).ready(function(){
+        $('#issues_table').DataTable();
+      });
+    })
+    .fail(function() {
+      alert('Could not get issues!');
+    });
+}
 
 // checkPRs makes an API call to see how many PRs this user has completed then
 // shows the results.

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -14,6 +14,9 @@
     <!-- Custom CSS -->
     <link href="/public/css/hacktoberfest.css" rel="stylesheet">
 
+    <!-- Extra CSS -->
+    <link href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.min.css">
+
     <!-- Google Fonts -->
     <link href='https://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
@@ -30,6 +33,8 @@
     <!-- Plugin JavaScript -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/scrollReveal.js/3.3.6/scrollreveal.min.js"></script>
+    <script src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"></script>
+    
 
     <!-- Page Specific JavaScript -->
     {{ partial "js" }}

--- a/templates/profile.tmpl
+++ b/templates/profile.tmpl
@@ -46,6 +46,23 @@
     <button id="check" class="btn btn-primary">Check my status!</button>
     </p>
     <div id="results"></div>
+
+    <h3> Open Issues </h3>
+    <br/>
+
+    <div id="issues_results">
+      <table id="issues_table" class="table table-stripedn" cellspacing="0" width="100%">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Repository</th>
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody id="issues">
+        </tbody>
+      </table>
+    </div>
   </section>
 </div>
 


### PR DESCRIPTION
1. I have added the issues endpoint.
2. By using this endpoint I query issues labeled as 'hacktoberfest' as well belonging to the orgs and projects specified on the main.go file.
3. The open issues are listed on the profile page within a table that handles pagination, the user is able to click on a button that redirects him/her to the issue oficial page...

It is pretty basic, I followed the same as the api endpoint of prs workflow.

See screenshot:

<img width="1196" alt="screen shot 2017-09-29 at 2 20 20 pm" src="https://user-images.githubusercontent.com/4277045/31027662-5ec1f95e-a521-11e7-8d46-a1824be42196.png">

