### PR TITLE
adjust responsive sponsor styles

### DIFF
--- a/public/css/hacktoberfest.css
+++ b/public/css/hacktoberfest.css
@@ -91,7 +91,7 @@ hr.light {
 
 .btn-dark {
   color: white;
-  background-color: #075642; !important }
+  background-color: #075642;}
   .btn-dark:hover {
     color: white;
     background-color: #2DA385;
@@ -124,14 +124,38 @@ hr.light {
   background: linear-gradient(to bottom right, #8d397c, #c98b2a);
 }
 
+.platinum-sponsors a {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+}
+
+.gold-sponsors a {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .platinum-sponsors img {
-  height: 5em;
-  margin-bottom: 2em;
+  max-height: 5em;
+  max-width: 100%;
 }
 
 .gold-sponsors img {
-  height: 4em;
-  margin-bottom: 2em;
+  max-height: 4em;
+  max-width: 100%;
 }
 
 #mainNav {

--- a/templates/home.tmpl
+++ b/templates/home.tmpl
@@ -47,27 +47,24 @@
     effort of our sponsors.
     </p>
 
-    <div class="row platinum-sponsors">
-      <div class="col-lg">
-        <a href="https://enterprisesolutions.accuweather.com/" target="_blank"><img src="public/images/logos/aes.svg" alt="AccuWeather Enterprise Solutions" /></a>
-      </div>
-      <div class="col-lg">
-        <a href="http://ulteriustech.com/" target="_blank"><img src="public/images/logos/ulterius.jpg" alt="Ulterius Technologies" /></a>
-      </div>
-    </div>
-
-    <div class="row gold-sponsors">
-      <div class="col-lg">
-        <a href="https://devict.org" target="_blank"><img src="public/images/logos/devict.svg" alt="devICT" /></a>
-      </div>
-      <div class="col-lg">
-        <a href="http://ennovar.wichita.edu" target="_blank"><img src="public/images/logos/ennovar.png" alt="Ennovar" /></a>
-      </div>
-      <div class="col-lg">
-        <a href="http://labor-party.com" target="_blank"><img src="public/images/logos/labor-party.svg" alt="The Labor Party" /></a>
-      </div>
-    </div>
+    <div class="row platinum-sponsors mb-5 mb-md-4">
+      <a href="https://enterprisesolutions.accuweather.com/" target="_blank" class="col-12 col-md mb-3"><img src="public/images/logos/aes.svg" alt="AccuWeather Enterprise Solutions"/></a>
+      <a href="http://ulteriustech.com/" target="_blank" class="col-12 col-md"><img src="public/images/logos/ulterius.jpg" alt="Ulterius Technologies"/></a>
   </div>
+  <div class="row gold-sponsors">
+      <a href="https://devict.org" target="_blank" class="col-12 col-sm mb-4">
+        <img src="public/images/logos/devict.svg" alt="devICT" class="img-fluid"/>
+      </a>
+
+      <a href="http://ennovar.wichita.edu" target="_blank" class="col-12 col-sm mb-4">
+        <img src="public/images/logos/ennovar.png" alt="Ennovar" class="img-fluid"/>
+      </a>
+
+      <a href="http://labor-party.com" target="_blank" class="col-12 col-sm mb-4">
+        <img src="public/images/logos/labor-party.svg" alt="The Labor Party" class="img-fluid"/>
+      </a>
+  </div>
+</div>
 </div>
 
 <section class="section-dark" id="about">


### PR DESCRIPTION
Expected: All sponsor logos remain completely visible, proportionately scaled, and at maximum available quality at all breakpoints.

Actual: Platinum sponsor logos overflow off right edge of viewport on small devices, Ulterius suffers from pixelation in an effort to match Accuweather's SVG when scaled.

What's changed: 
- Removed important declaration that wasn't being applied due to ending up on the wrong side of a semicolon, and that would have broken the button's hover state if it were to be applied. If this change was made in error, just let me know.
- Column classes have been applied directly to anchor tags with container divs removed, sponsor section has been aligned via flexbox with appropriate prefixes, alignment and scaling have been adjusted to ensure precise scaling across display sizes

Efforts were made to preserve the hierarchy of platinum vs. gold sponsors at each size, though difficult on mobile displays. Spacing between individual logos and each row should be relatively consistent with original state. 

Part of an ongoing effort to address #13 . Pagination when viewing the issues list is my next target, seems to suffer from small tap targets which harm usability. 