### PR TITLE
Fixed nav bar wrapping to new line on xs viewports

### DIFF
--- a/public/css/hacktoberfest.css
+++ b/public/css/hacktoberfest.css
@@ -218,10 +218,7 @@ hr.light {
 
 @media (max-width: 360px) {
   .navbar-brand {
-    font-size: 1.125rem; }
-  .navbar-toggler {
-    font-size: 1.25rem; 
-    padding: .25rem .3625rem; } }
+    font-size: 1rem; } }
 
 header {
   width: 100%;


### PR DESCRIPTION
Top nav's menu button was wrapping to a new line on screens <361px wide.
Now it's OK from 320px on up.
Tweaked the size and spacing of `.navbar-brand` and the toggler to help them fit together.

part of #13 