### PR TITLE
feat: when checking PR status the client side current year is shown

### DIFF
--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -73,10 +73,11 @@ function checkPRs() {
         results.prepend(t);
       });
 
+      var today = new Date();
       var message;
       if (data.length === 0) {
         // No PRs
-        message = 'You have not opened any Pull Requests on public GitHub projects during October 2019.';
+        message = 'You have not opened any Pull Requests on public GitHub projects during October ' + today.getFullYear() + '.';
       } else if (validCount === 0) {
         // Some PRs but none counts
         message = 'You have ' + data.length + ' Pull Request(s) but none of them are against approved repos.';


### PR DESCRIPTION
Fixes issue #91 

This might be somewhat of a bandaid fix but I think it should be a reasonable solution for now. The year is now dynamically inserted into the copy from the client side date in Javascript. This obviously has some downsides as it will not track with the server side data past December. However, I think most people visit the site from Sept. to Nov. so it might be okay.